### PR TITLE
add clarification regarding apple silicon support and links to relevant issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Your new project consists of:
   RISC0_DEV_MODE=false forge test -vvv
   ```
 
-  Producing the [Groth16 SNARK proofs][Groth16] for this test requires running on an x86 machine with [Docker] installed, or using [Bonsai](#configuring-bonsai).
+  Producing the [Groth16 SNARK proofs][Groth16] for this test requires running on an x86 machine with [Docker] installed, or using [Bonsai](#configuring-bonsai). Apple silicon is currently unsupported for local proving, you can find out more info in the relevant issues [here](https://github.com/risc0/risc0/issues/1520) and [here](https://github.com/risc0/risc0/issues/1749). 
 
 ## Develop Your Application
 


### PR DESCRIPTION
Clarification specifically around stark2snark support on apple silicon. Specifically, similar to [#1952](https://github.com/risc0/risc0/pull/1952). 

This was a major issue for some users on the Discord recently (see [here](https://discord.com/channels/953703904086994974/1243250690344751227/1244567425349849138) and [here](https://discord.com/channels/953703904086994974/953703904086994977/1241971552312889396)) so extra clarification was needed.