### PR TITLE
Remove incorrect branch on .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,3 @@
 [submodule "lib/risc0-ethereum"]
 	path = lib/risc0-ethereum
 	url = https://github.com/risc0/risc0-ethereum
-	branch = v1.0.0-rc.6


### PR DESCRIPTION
https://stackoverflow.com/questions/8044583/how-can-i-move-a-tag-on-a-git-branch-to-a-different-commit states we cannot use tags, so this branch = tag is broken.

Instead of updating here, we will manage commits for sub-modules manually and locked into the tags/releases for known working versions (in #124)