### PR TITLE
WEB3-155: Fix two broken links in `methods/README.md`

### DIFF
--- a/methods/README.md
+++ b/methods/README.md
@@ -5,15 +5,13 @@ This is where you will define one or more [guest programs] to act as a coprocess
 
 > In typical use cases, the only code in this directory that you will need to edit is inside [guest/src/bin].
 
+## Writing Guest Code
 
-### Writing Guest Code
-
-To learn to write code for the zkVM, we recommend [Guest Code 101].
+To learn to write code for the zkVM, we recommend the [Hello World tutorial][zkvm-hello-world].
 
 Examples of what you can do in the guest can be found in the [RISC Zero examples].
 
-
-### From Guest Code to Binary File
+## From Guest Code to Binary File
 
 Code in the `methods/guest` directory will be compiled into one or more binaries.
 
@@ -21,11 +19,10 @@ Build configuration for the methods is included in `methods/build.rs`.
 
 Each will have a corresponding image ID, which is a hash identifying the program.
 
-
 [zkVM]: https://dev.risczero.com/zkvm
 [RISC Zero]: https://www.risczero.com/
 [guest programs]: https://dev.risczero.com/terminology#guest-program
 [on-chain logic]: ../contracts/
 [guest/src/bin]: ./guest/src/bin/
-[Guest Code 101]: https://dev.risczero.com/zkvm/developer-guide/guest-code-101
-[RISC Zero examples]: https://github.com/risc0/tree/v0.18.0/examples
+[zkvm-hello-world]: https://dev.risczero.com/api/zkvm/tutorials/hello-world
+[RISC Zero examples]: https://github.com/risc0/risc0/tree/release-1.1/examples


### PR DESCRIPTION
I found a couple of broken links using `git ls-files '*.md' | xargs lychee --base . --cache --`. This PR fixes them and additionally formats the modified .md file.
