### PR TITLE
WEB3-206: Add git submodule update --init to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,19 @@ Your new project consists of:
 
 ### Build the Code
 
+- Update git submodules.
+
+  ```sh
+  git submodule update --init
+  ```
+
 - Builds for zkVM program, the publisher app, and any other Rust code.
 
   ```sh
   cargo build
   ```
 
-- Build your Solidity smart contracts
+- Build your Solidity smart contracts.
 
   > NOTE: `cargo build` needs to run first to generate the `ImageID.sol` contract.
 


### PR DESCRIPTION
In order to make sure local foundry deps are up-to-date, `git submodule update --init` should be ran